### PR TITLE
ci: convert workflows to workflow_dispatch-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,20 +4,8 @@ env:
   PYTHON_VERSION: '3.12.11'
   UV_VERSION: '0.7.18'
 
+# Manual only — no push/pull_request CI triggers
 on:
-  push:
-    branches: [ main, master, 'github-init', 'setup/**' ]
-    paths:
-      - 'docker-compose.yml'
-      - 'Dockerfile'
-      - 'requirements.txt'
-      - 'scripts/**'
-      - 'trackers/**'
-      - 'CHANGELOG.md'
-      - '.github/workflows/ci.yml'
-      - 'src/**'
-  pull_request:
-    branches: [ '**' ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Removes automatic push/pull_request/schedule CI triggers. Use workflow_dispatch to run CI manually.